### PR TITLE
Ensure canvas fills viewport

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #eef5ff;
+}


### PR DESCRIPTION
## Summary
- extend the base styles to give the html, body, and root elements a full-height layout
- remove default body margin and set a background color that matches the scene

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d434c448448329b67f4479ad59909c