### PR TITLE
Fix Rapier initialization and add loading fallbacks

### DIFF
--- a/src/lib/rapier-compat.js
+++ b/src/lib/rapier-compat.js
@@ -1,0 +1,119 @@
+import * as RapierModule from '@dimforge/rapier3d-compat/rapier.es.js'
+import initWasm from '@dimforge/rapier3d-compat/rapier_wasm3d.js'
+import wasmUrl from '@dimforge/rapier3d-compat/rapier_wasm3d_bg.wasm?url'
+
+let initPromise
+
+export async function init(options = {}) {
+  if (!initPromise) {
+    const wasmSource = options.wasm ?? wasmUrl
+    initPromise = initWasm(wasmSource).catch((error) => {
+      initPromise = undefined
+      throw error
+    })
+  }
+
+  return initPromise
+}
+
+const patchedDefault = {
+  ...RapierModule.default,
+  init,
+}
+
+export {
+  ActiveCollisionTypes,
+  ActiveEvents,
+  ActiveHooks,
+  Ball,
+  BroadPhase,
+  CCDSolver,
+  Capsule,
+  CharacterCollision,
+  CoefficientCombineRule,
+  Collider,
+  ColliderDesc,
+  ColliderSet,
+  ColliderShapeCastHit,
+  Cone,
+  ConvexPolyhedron,
+  Cuboid,
+  Cylinder,
+  DebugRenderBuffers,
+  DebugRenderPipeline,
+  DynamicRayCastVehicleController,
+  EventQueue,
+  FeatureType,
+  FixedImpulseJoint,
+  FixedMultibodyJoint,
+  GenericImpulseJoint,
+  HalfSpace,
+  HeightFieldFlags,
+  Heightfield,
+  ImpulseJoint,
+  ImpulseJointSet,
+  IntegrationParameters,
+  IslandManager,
+  JointAxesMask,
+  JointData,
+  JointType,
+  KinematicCharacterController,
+  MassPropsMode,
+  MotorModel,
+  MultibodyJoint,
+  MultibodyJointSet,
+  NarrowPhase,
+  PhysicsPipeline,
+  PidAxesMask,
+  PidController,
+  PointColliderProjection,
+  PointProjection,
+  Polyline,
+  PrismaticImpulseJoint,
+  PrismaticMultibodyJoint,
+  Quaternion,
+  QueryFilterFlags,
+  QueryPipeline,
+  Ray,
+  RayColliderHit,
+  RayColliderIntersection,
+  RayIntersection,
+  RevoluteImpulseJoint,
+  RevoluteMultibodyJoint,
+  RigidBody,
+  RigidBodyDesc,
+  RigidBodySet,
+  RigidBodyType,
+  RopeImpulseJoint,
+  RotationOps,
+  RoundCone,
+  RoundConvexPolyhedron,
+  RoundCuboid,
+  RoundCylinder,
+  RoundTriangle,
+  SdpMatrix3,
+  SdpMatrix3Ops,
+  Segment,
+  SerializationPipeline,
+  Shape,
+  ShapeCastHit,
+  ShapeContact,
+  ShapeType,
+  SolverFlags,
+  SphericalImpulseJoint,
+  SphericalMultibodyJoint,
+  SpringImpulseJoint,
+  TempContactForceEvent,
+  TempContactManifold,
+  TriMesh,
+  TriMeshFlags,
+  Triangle,
+  UnitImpulseJoint,
+  UnitMultibodyJoint,
+  Vector3,
+  VectorOps,
+  World,
+  version,
+} from '@dimforge/rapier3d-compat/rapier.es.js'
+
+export default patchedDefault

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,22 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath } from 'node:url'
+
+const rapierCompatPath = fileURLToPath(new URL('./src/lib/rapier-compat.js', import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      {
+        find: /^@dimforge\/rapier3d-compat$/,
+        replacement: rapierCompatPath,
+      },
+    ],
+  },
+  optimizeDeps: {
+    exclude: ['@dimforge/rapier3d-compat'],
+  },
+  assetsInclude: ['**/*.wasm'],
 })


### PR DESCRIPTION
## Summary
- add a Rapier wrapper and Vite alias so the WASM physics bundle always loads correctly
- gate the physics scene behind an init hook and show loading/error overlays to avoid a black screen

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d44fd4c09883298340bea2a5b061aa