### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ const rapierCompatPath = fileURLToPath(new URL('./src/lib/rapier-compat.js', imp
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/quantum_physics/',
   plugins: [react()],
   resolve: {
     alias: [


### PR DESCRIPTION
## Summary
- set the Vite base path to `/quantum_physics/` so built assets resolve on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4d7b56ad0832993f910b80672e317