### PR TITLE
Automate GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy static site
+
+on:
+  push:
+    branches: [work]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build site
+        run: npm run build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,10 @@
-# Logs
-logs
-*.log
+node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
-lerna-debug.log*
-
-node_modules
-dist
-dist-ssr
-*.local
-
-# Editor directories and files
-.vscode/*
-!.vscode/extensions.json
-.idea
 .DS_Store
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
+/dist
+/docs
+.vscode
+.idea

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,28 @@
+# Quantum Physics Prototype
 
+This project is built with [Vite](https://vitejs.dev/) and React. The production bundle must be generated before you deploy it to a static host; otherwise the browser receives the raw JSX sources and refuses to execute them because of the `text/jsx` MIME type.
+
+## Local development
+
+```bash
+npm install
+npm run dev
+```
+
+## Production build
+
+```bash
+npm run build
+```
+
+The optimized assets are written to the `dist/` directory. Serve that directory (for example with `npm run preview`) or publish it via GitHub Pages.
+
+## GitHub Pages deployment
+
+A GitHub Actions workflow is included in `.github/workflows/deploy.yml`. To enable automated deployments:
+
+1. Push the project to GitHub.
+2. In the repository settings, enable GitHub Pages and select **GitHub Actions** as the source.
+3. Every push to the `work` branch builds the project and publishes the contents of `dist/` to Pages.
+
+This workflow ensures that the compiled JavaScript bundle is served with the correct MIME type, eliminating the "Expected a JavaScript-or-Wasm module" error.

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,10 @@ const rapierCompatPath = fileURLToPath(new URL('./src/lib/rapier-compat.js', imp
 export default defineConfig({
   base: '/quantum_physics/',
   plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
   resolve: {
     alias: [
       {


### PR DESCRIPTION
## Summary
- stop tracking the generated `docs` build output and ignore future builds
- point the Vite production build back to the default `dist/` directory
- document the build/deploy flow and add a GitHub Actions workflow that builds `dist/` and publishes it to GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4d8cfdd9c8329bb5aee009ababa86