### PR TITLE
Fix relative asset paths for static hosting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,7 +69,7 @@ function useTouchDevice() {
       const handler = () => determine();
       try {
         mediaQuery.addEventListener("change", handler);
-      } catch (error) {
+      } catch {
         // Safari < 14
         mediaQuery.addListener(handler);
       }
@@ -77,7 +77,7 @@ function useTouchDevice() {
       return () => {
         try {
           mediaQuery.removeEventListener("change", handler);
-        } catch (error) {
+        } catch {
           mediaQuery.removeListener(handler);
         }
       };

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ const rapierCompatPath = fileURLToPath(new URL('./src/lib/rapier-compat.js', imp
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/quantum_physics/',
+  base: './',
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- switch the Vite base path to a relative value so the production bundle can be served from any subdirectory without browsers fetching the raw JSX entry
- clean up unused catch parameters that eslint flagged in the touch detection hook

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d587434b0083298cb3de8ab38a405c